### PR TITLE
fix: align Prisma schema and types by removing unused fields and resolving TS errors

### DIFF
--- a/src/types/github.ts
+++ b/src/types/github.ts
@@ -1,47 +1,19 @@
 export interface GitHubActivity {
   userId: string;
-  type: 'commit' | 'pull_request' | 'contribution';
+  type: 'contribution' | 'commit' | 'pull_request';
   repository: string;
   title: string;
   url: string;
   eventId: string;
   createdAt: Date;
-  contributionCount?: number;
-}
+  contributionCount: number;
 
-// GitHubEvent represents the structure of a GitHub API event (REST API)
-export interface GitHubEvent {
-  id: string;
-  type: string;
-  repo: {
-    id: number;
-    name: string;
-    url: string;
-  };
-  payload: {
-    commits?: Array<{
-      sha: string;
-      message: string;
-      url: string;
-    }>;
-    pull_request?: {
-      number: number;
-      title: string;
-      html_url: string;
-    };
-    issue?: {
-      number: number;
-      title: string;
-      html_url: string;
-    };
-  };
-  created_at: string;
 }
 
 // ActivityFilter defines the filter criteria for querying GitHub activities
 export interface ActivityFilter {
   userId: string;
-  type?: 'commit' | 'pull_request' | 'issue' | 'Contribution';
+  type?: 'contribution' | 'commit' | 'pull_request';
   repository?: string;
   createdAt?: {
     gte?: Date;
@@ -101,4 +73,24 @@ export interface GitHubGraphQLResponse {
   errors?: Array<{
     message: string;
   }>;
+}
+
+// GroupByStats represents the result of groupBy queries for stats
+export interface GroupByStats {
+  type: string;
+  _count: number;
+}
+
+// GroupByTimeline represents the result of groupBy queries for timeline
+export interface GroupByTimeline {
+  createdAt: Date;
+  _sum: {
+    contributionCount: number | null;
+  };
+}
+
+// GroupByRepository represents the result of groupBy queries for repository distribution
+export interface GroupByRepository {
+  repository: string;
+  _count: number;
 }


### PR DESCRIPTION
## 주요 변경 사항

- `state` 및 `mergedAt` 필드, GitHubActivity 타입에서 제거
- TypeScript 오류(TS7006, TS18046) 해결을 위한 콜백 함수의 타입 명시 (`reduce`, `map`, `sort`)
- `type` 필드를 'contribution' | 'commit' | 'pull_request' 로 통일 및, 'issue' 제거
- Prisma의 groupBy 결과를 위한 타입 (`GroupByStats`, `GroupByTimeline`, `GroupByRepository`) 명시

## 목적

배포 과정에서 발생한 TypeScript 빌드 오류 해결을 통한 안정적인 배포 유도

## 참고 사항

- **DB 마이그레이션 필요**: `state`, `mergedAt` 필드 제거에 따른 Prisma 마이그레이션 반영 필수 (추후 반영 예정)
