### PR TITLE
fix: make contributionCount optional and resolve TS errors in activity creation

### DIFF
--- a/prisma/migrations/20250511145349_remove_state_and_merged_at/migration.sql
+++ b/prisma/migrations/20250511145349_remove_state_and_merged_at/migration.sql
@@ -1,0 +1,10 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `mergedAt` on the `GitHubActivity` table. All the data in the column will be lost.
+  - You are about to drop the column `state` on the `GitHubActivity` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "GitHubActivity" DROP COLUMN "mergedAt",
+DROP COLUMN "state";

--- a/prisma/migrations/20250511150142_make_contribution_count_optional/migration.sql
+++ b/prisma/migrations/20250511150142_make_contribution_count_optional/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "GitHubActivity" ALTER COLUMN "contributionCount" DROP NOT NULL,
+ALTER COLUMN "contributionCount" DROP DEFAULT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -36,9 +36,7 @@ model GitHubActivity {
   description String?  @db.Text
   url         String
   eventId     String   @unique
-  contributionCount Int @default(1)  // 각 활동의 contribution 수
-  state       String?  // PullRequest의 상태 (MERGED, CLOSED)
-  mergedAt    DateTime? // PullRequest가 머지된 시간
+  contributionCount Int?  // optional로 변경, 기본값 제거
   createdAt   DateTime @default(now())
   user        User     @relation(fields: [userId], references: [id], onDelete: Cascade)
 

--- a/src/types/github.ts
+++ b/src/types/github.ts
@@ -1,13 +1,14 @@
 export interface GitHubActivity {
+  id: string;
   userId: string;
   type: 'contribution' | 'commit' | 'pull_request';
   repository: string;
   title: string;
+  description?: string;
   url: string;
   eventId: string;
   createdAt: Date;
-  contributionCount: number;
-
+  contributionCount?: number;
 }
 
 // ActivityFilter defines the filter criteria for querying GitHub activities


### PR DESCRIPTION
## 주요 변경 사항

- `contributionCount` optional로 수정, default(1) 제거
- 사용되지 않던 `state`, `mergedAt` 필드 삭제 (PullRequest 활동 관련)
- GitHubActivity 생성 시 타입 불일치 문제(TS2345) 해결
  - `GitHubActivityInput` 타입을 도입해 `id` 없이 객체 생성 가능하도록 수정
  - `fetchUserActivities` 내 불필요한 `id: ''` 제거

## 목적

Prisma 스키마 정리에 따라 불필요한 필드를 제거 및 TypeScript 타입 오류를 해결하여 배포에서 오류 없도록 하기 위함