### PR TITLE
feat: Implement secure cookie-based JWT auth and refactor project structure

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@prisma/client": "^6.7.0",
     "@types/express-rate-limit": "^5.1.3",
     "axios": "^1.9.0",
+    "cookie-parser": "^1.4.7",
     "cors": "^2.8.5",
     "dotenv": "^16.5.0",
     "express": "^4.18.2",
@@ -25,6 +26,7 @@
     "pg": "^8.11.3"
   },
   "devDependencies": {
+    "@types/cookie-parser": "^1.4.8",
     "@types/cors": "^2.8.17",
     "@types/express": "^4.17.21",
     "@types/jsonwebtoken": "^9.0.9",

--- a/package.json
+++ b/package.json
@@ -2,10 +2,10 @@
   "name": "git-test-backend",
   "version": "1.0.0",
   "description": "For testing purposes, GitHub activity tracking backend service",
-  "main": "dist/index.js",
+  "main": "dist/server.js",
   "scripts": {
-    "start": "node dist/index.js",
-    "dev": "nodemon src/index.ts",
+    "start": "node dist/server.js",
+    "dev": "nodemon src/server.ts",
     "build": "tsc",
     "migrate": "ts-node src/db/migrations/migrate.ts"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import cookieParser from 'cookie-parser';
 import cors from 'cors';
 import dotenv from 'dotenv';
 import express from 'express';
@@ -16,6 +17,7 @@ app.use(cors({
   credentials: true,
 }));
 app.use(express.json());
+app.use(cookieParser());
 
 // Database connection
 connectDB();

--- a/src/middlewares/authMiddleware.ts
+++ b/src/middlewares/authMiddleware.ts
@@ -16,14 +16,15 @@ declare global {
 }
 
 export const authenticateToken = (req: Request, res: Response, next: NextFunction) => {
-  // 토큰을 쿠키 또는 Authorization 헤더에서 가져옴 (둘 다 지원)
-  let token = req.cookies?.auth_token;
+  // Authorization 헤더에서 토큰 확인
+  const authHeader = req.headers['authorization'];
+  const headerToken = authHeader && authHeader.split(' ')[1];
   
-  // 쿠키에 토큰이 없으면 Authorization 헤더에서 확인 (기존 방식 지원)
-  if (!token) {
-    const authHeader = req.headers['authorization'];
-    token = authHeader && authHeader.split(' ')[1];
-  }
+  // 쿠키에서 토큰 확인
+  const cookieToken = req.cookies?.auth_token;
+  
+  // 헤더 또는 쿠키에서 토큰 가져오기
+  const token = headerToken || cookieToken;
 
   if (!token) {
     return res.status(401).json({ message: 'No token provided' });

--- a/src/middlewares/authMiddleware.ts
+++ b/src/middlewares/authMiddleware.ts
@@ -9,7 +9,6 @@ declare global {
         id: string;
         githubId: string;
         username: string;
-        accessToken: string;
         image?: string;
       };
     }
@@ -17,8 +16,14 @@ declare global {
 }
 
 export const authenticateToken = (req: Request, res: Response, next: NextFunction) => {
-  const authHeader = req.headers['authorization'];
-  const token = authHeader && authHeader.split(' ')[1];
+  // 토큰을 쿠키 또는 Authorization 헤더에서 가져옴 (둘 다 지원)
+  let token = req.cookies?.auth_token;
+  
+  // 쿠키에 토큰이 없으면 Authorization 헤더에서 확인 (기존 방식 지원)
+  if (!token) {
+    const authHeader = req.headers['authorization'];
+    token = authHeader && authHeader.split(' ')[1];
+  }
 
   if (!token) {
     return res.status(401).json({ message: 'No token provided' });
@@ -29,7 +34,6 @@ export const authenticateToken = (req: Request, res: Response, next: NextFunctio
       id: string;
       githubId: string;
       username: string;
-      accessToken: string;
       image?: string;
     };
     req.user = decoded;

--- a/src/routes/activityRoutes.ts
+++ b/src/routes/activityRoutes.ts
@@ -11,7 +11,6 @@ interface AuthRequest extends Request {
     id: string;
     githubId: string;
     username: string;
-    accessToken: string;
     image?: string;
   };
 }
@@ -69,7 +68,6 @@ router.get('/stats', async (req: AuthRequest, res: Response) => {
     const { period } = req.query as { period?: string };
     const where: ActivityFilter = { userId: req.user!.id };
 
-    // 기간별 필터링
     if (period) {
       const now = new Date();
       const periods: { [key: string]: number } = {
@@ -114,7 +112,6 @@ router.get('/analytics', async (req: AuthRequest, res: Response) => {
     if (period === 'all') {
       // No date filtering for 'all' period
     } else if (period === 'year' && year) {
-      // Specific year filtering
       const startDate = new Date(parseInt(year), 0, 1);
       const endDate = new Date(parseInt(year), 11, 31, 23, 59, 59);
       where.createdAt = {
@@ -122,7 +119,6 @@ router.get('/analytics', async (req: AuthRequest, res: Response) => {
         lte: endDate
       };
     } else if (period) {
-      // Default period filtering (day, week, month, year)
       const now = new Date();
       const periods: { [key: string]: number } = {
         day: 24 * 60 * 60 * 1000,
@@ -220,7 +216,7 @@ router.post('/sync', syncLimiter, async (req: AuthRequest, res: Response) => {
       return res.status(401).json({ message: 'GitHub access token not found' });
     }
 
-    const activities = await fetchUserActivities(user.accessToken, req.user!.id, user.username);
+    const activities = await fetchUserActivities(req.user!.id, user.username);
 
     res.json({
       message: 'Contributions synced successfully',

--- a/src/routes/authRoutes.ts
+++ b/src/routes/authRoutes.ts
@@ -54,12 +54,11 @@ router.get('/callback/github', async (req, res) => {
       create: userData,
     });
 
-    // JWT 토큰 생성
+    // JWT 토큰 생성 - accessToken을 제외하여 보안 강화
     const payload = { 
       id: user.id,
       githubId: user.githubId,
       username: user.username,
-      accessToken: access_token,
       image: user.image
     };
 
@@ -69,8 +68,16 @@ router.get('/callback/github', async (req, res) => {
       { expiresIn: authConfig.jwt.expiresIn }
     );
 
-    // 프론트엔드로 리다이렉트 (토큰 포함)
-    res.redirect(`${process.env.FRONTEND_URL}/auth/callback?token=${token}`);
+    // 쿠키로 토큰 전송 (URL 파라미터 방식 대신)
+    res.cookie('auth_token', token, {
+      httpOnly: true,  // JavaScript에서 접근 불가
+      secure: process.env.NODE_ENV === 'production',  // 프로덕션 환경에서는 HTTPS만 허용
+      sameSite: 'lax',  // CSRF 보호
+      maxAge: 24 * 60 * 60 * 1000  // 1일
+    });
+
+    // 토큰을 URL 파라미터로 전송하지 않고 리다이렉트
+    res.redirect(`${process.env.FRONTEND_URL}/auth/callback`);
   } catch (error) {
     console.error('GitHub OAuth error:', error);
     res.redirect(`${process.env.FRONTEND_URL}/auth/error`);
@@ -99,8 +106,13 @@ router.get('/session', authenticateToken, async (req, res) => {
   }
 });
 
-// 로그아웃
+// 로그아웃 - 쿠키 제거 기능 추가
 router.post('/signout', (req, res) => {
+  res.clearCookie('auth_token', {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === 'production',
+    sameSite: 'lax'
+  });
   res.json({ message: 'Signed out successfully' });
 });
 

--- a/src/routes/authRoutes.ts
+++ b/src/routes/authRoutes.ts
@@ -71,12 +71,13 @@ router.get('/callback/github', async (req, res) => {
     // 쿠키로 토큰 전송 (URL 파라미터 방식 대신)
     res.cookie('auth_token', token, {
       httpOnly: true,  // JavaScript에서 접근 불가
-      secure: process.env.NODE_ENV === 'production',  // 프로덕션 환경에서는 HTTPS만 허용
+      secure: true, // HTTPS 필수 (개발/프로덕션 모두)
       sameSite: 'none',  // 크로스 도메인 쿠키를 위해 'none'으로 변경
       maxAge: 24 * 60 * 60 * 1000,  // 1일
+      path: '/',
       domain: process.env.COOKIE_DOMAIN  // 도메인 설정 추가
     });
-
+    
     // 토큰을 URL 파라미터로 전송하지 않고 리다이렉트
     res.redirect(`${process.env.FRONTEND_URL}/auth/callback`);
   } catch (error) {
@@ -109,10 +110,12 @@ router.get('/session', authenticateToken, async (req, res) => {
 
 // 로그아웃 - 쿠키 제거 기능 추가
 router.post('/signout', (req, res) => {
-  res.clearCookie('auth_token', {
+    res.clearCookie('auth_token', {
     httpOnly: true,
-    secure: process.env.NODE_ENV === 'production',
-    sameSite: 'lax'
+    secure: true, // HTTPS 필수
+    sameSite: 'none',
+    path: '/',
+    domain: process.env.COOKIE_DOMAIN  // 도메인 설정 추가
   });
   res.json({ message: 'Signed out successfully' });
 });

--- a/src/routes/authRoutes.ts
+++ b/src/routes/authRoutes.ts
@@ -72,8 +72,9 @@ router.get('/callback/github', async (req, res) => {
     res.cookie('auth_token', token, {
       httpOnly: true,  // JavaScript에서 접근 불가
       secure: process.env.NODE_ENV === 'production',  // 프로덕션 환경에서는 HTTPS만 허용
-      sameSite: 'lax',  // CSRF 보호
-      maxAge: 24 * 60 * 60 * 1000  // 1일
+      sameSite: 'none',  // 크로스 도메인 쿠키를 위해 'none'으로 변경
+      maxAge: 24 * 60 * 60 * 1000,  // 1일
+      domain: process.env.COOKIE_DOMAIN  // 도메인 설정 추가
     });
 
     // 토큰을 URL 파라미터로 전송하지 않고 리다이렉트

--- a/src/server.ts
+++ b/src/server.ts
@@ -15,6 +15,8 @@ const app = express();
 app.use(cors({
   origin: process.env.FRONTEND_URL,
   credentials: true,
+  methods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],
+  allowedHeaders: ['Content-Type', 'Authorization']
 }));
 app.use(express.json());
 app.use(cookieParser());


### PR DESCRIPTION
## 변경 사항

- GitHub accessToken을 직접 사용하지 않도록 JWT 인증 구조 개선
- HTTP-only 쿠키 기반 토큰 인증 방식 도입
- SameSite=None, Secure=true 옵션으로 cross-domain 쿠키 설정 강화
- 인증 로직 분리 및 프로젝트 구조 정비로 유지보수성 향상


## 목적

- 세션 유사한 인증 흐름 구현을 위한 쿠키 기반 인증 도입
- 프론트엔드에서의 accessToken 노출 최소화
- 보안성 강화 및 멀티 도메인 환경 대응
- 인증 로직의 재사용성 및 유지보수성 향상