### PR TITLE
feat: Add contribution chart endpoint for README.md (support for authenticated/public GitHub users)

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
     "@prisma/client": "^6.7.0",
     "@types/express-rate-limit": "^5.1.3",
     "axios": "^1.9.0",
+    "chart.js": "^4.4.9",
+    "chartjs-node-canvas": "^5.0.0",
     "cookie-parser": "^1.4.7",
     "cors": "^2.8.5",
     "dotenv": "^16.5.0",

--- a/package.json
+++ b/package.json
@@ -21,8 +21,6 @@
     "express-session": "^1.18.1",
     "helmet": "^7.1.0",
     "jsonwebtoken": "^9.0.2",
-    "passport": "^0.7.0",
-    "passport-github2": "^0.1.12",
     "pg": "^8.11.3"
   },
   "devDependencies": {

--- a/src/controllers/chartImageController.ts
+++ b/src/controllers/chartImageController.ts
@@ -1,0 +1,144 @@
+import { ContributionTimelineEntry } from '@/types/github';
+import { Chart, registerables } from 'chart.js';
+import { ChartJSNodeCanvas } from 'chartjs-node-canvas';
+import { Request, Response } from 'express';
+import { getContributionTimeline, getUserByUsername } from '../services/analyticsService';
+import { fetchPublicContributionCalendarByUsername } from '../services/githubService';
+
+Chart.register(...registerables);
+
+const DEFAULT_OUTPUT_WIDTH = 800;
+const DEFAULT_OUTPUT_HEIGHT = 400;
+const MAX_OUTPUT_WIDTH = 2000;
+const MAX_OUTPUT_HEIGHT = 2000;
+
+const formatDateForChart = (dateString: string | Date): string => {
+  const date = new Date(dateString);
+  return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+};
+
+export const generateContributionsChart = async (req: Request, res: Response) => {
+  try {
+    const username = req.query.username as string;
+    const period = req.query.period as string | undefined;
+    const year = req.query.year as string | undefined;
+
+    let outputWidth = parseInt(req.query.width as string, 10) || DEFAULT_OUTPUT_WIDTH;
+    let outputHeight = parseInt(req.query.height as string, 10) || DEFAULT_OUTPUT_HEIGHT;
+
+    outputWidth = Math.max(100, Math.min(outputWidth, MAX_OUTPUT_WIDTH));
+    outputHeight = Math.max(100, Math.min(outputHeight, MAX_OUTPUT_HEIGHT));
+
+    if (!username) {
+      return res.status(400).json({ message: 'Username query parameter is required' });
+    }
+    if (!/^[a-zA-Z0-9](?:[a-zA-Z0-9]|-(?=[a-zA-Z0-9])){0,38}$/.test(username)) {
+      return res.status(400).json({ message: 'Invalid GitHub username format' });
+    }
+
+    let timelineData: ContributionTimelineEntry[] = [];
+    let chartTitleUsername = username;
+
+    const localUser = await getUserByUsername(username);
+
+    if (localUser) {
+      chartTitleUsername = localUser.username;
+      timelineData = await getContributionTimeline(localUser.id, period, year);
+    } else {
+      const githubPat = process.env.GITHUB_PAT;
+      if (!githubPat) {
+        console.error('GITHUB_PAT environment variable is not set.');
+        return res.status(503).send('Service temporarily unavailable due to configuration error.');
+      }
+      try {
+        timelineData = await fetchPublicContributionCalendarByUsername(username, githubPat, period, year) as ContributionTimelineEntry[];
+      } catch (githubError: unknown) {
+        let errorMessage = 'Failed to fetch data from GitHub.';
+        let statusCode = 502;
+        if (githubError instanceof Error) {
+          console.error(`Error fetching public GitHub data for ${username}:`, githubError.message);
+          if (githubError.message.toLowerCase().includes('not found')) {
+            statusCode = 404;
+            errorMessage = `GitHub user '${username}' not found.`;
+          } else if (githubError.message.toLowerCase().includes('authentication failed')) {
+            statusCode = 503;
+            errorMessage = 'GitHub API authentication issue.';
+          }
+        }
+        return res.status(statusCode).send(errorMessage);
+      }
+    }
+
+    if (timelineData.length === 0) {
+      return res.status(404).send(); 
+    }
+
+    const chartJSNodeCanvas = new ChartJSNodeCanvas({ width: outputWidth, height: outputHeight });
+
+    const labels = timelineData.map(entry => formatDateForChart(entry.date));
+    const dataCounts = timelineData.map(entry => entry.count);
+
+    const configuration = {
+      type: 'line' as const,
+      data: {
+        labels: labels,
+        datasets: [
+          {
+            label: `Contributions (${period || 'default'})`,
+            data: dataCounts,
+            borderColor: 'rgb(75, 192, 192)',
+            backgroundColor: 'rgba(75, 192, 192, 0.2)',
+            tension: 0.1,
+            fill: true,
+          },
+        ],
+      },
+      options: {
+        responsive: true,
+        maintainAspectRatio: false,
+        plugins: {
+          legend: {
+            position: 'top' as const,
+          },
+          title: {
+            display: true,
+            text: `Contribution Analytics for ${username}`,
+            font: { size: 18 }, // Adjusted font size
+          },
+        },
+        scales: {
+          x: {
+            ticks: {
+              font: { size: 12 },
+              autoSkip: true,
+              maxTicksLimit: 15,
+            },
+          },
+          y: {
+            beginAtZero: true,
+            ticks: {
+              font: { size: 12 },
+            },
+          },
+        },
+      },
+    };
+
+    const buffer = await chartJSNodeCanvas.renderToBuffer(configuration);
+
+    res.setHeader('Content-Type', 'image/png');
+    res.send(buffer);
+
+  } catch (error: unknown) {
+    let message = 'Error generating chart image.';
+    if (error instanceof Error) {
+      console.error('Unhandled error in generateContributionsChart:', error.message);
+      message = error.message;
+    } else {
+      console.error('Unhandled non-Error exception in generateContributionsChart:', error);
+    }
+    if (!res.headersSent) {
+      res.status(500).send(message);
+    }
+  }
+}; 

--- a/src/routes/activityRoutes.ts
+++ b/src/routes/activityRoutes.ts
@@ -1,6 +1,7 @@
 import type { ActivityFilter, GroupByStats, GroupByTimeline } from '@/types/github';
 import express, { Request, Response } from 'express';
 import prisma from '../config/db';
+import { generateContributionsChart } from '../controllers/chartImageController';
 import { authenticateToken } from '../middlewares/authMiddleware';
 import { autoSyncLimiter, syncLimiter } from '../middlewares/rateLimiter';
 import { fetchUserActivities, setupAutoSync, stopAutoSync } from '../services/githubService';
@@ -17,6 +18,7 @@ interface AuthRequest extends Request {
 
 const router = express.Router();
 
+router.get('/chart.png', generateContributionsChart);
 router.use(authenticateToken);
 
 // Get user's GitHub activities

--- a/src/services/analyticsService.ts
+++ b/src/services/analyticsService.ts
@@ -1,0 +1,67 @@
+import { ActivityFilter, ContributionTimelineEntry } from '@/types/github';
+import prisma from '../config/db';
+
+export const getUserByUsername = async (username: string): Promise<{ id: string; githubId: string; username: string } | null> => {
+  return prisma.user.findFirst({
+    where: { username },
+    select: { id: true, githubId: true, username: true },
+  });
+};
+
+export const getContributionTimeline = async (
+  userId: string,
+  period?: string,
+  year?: string
+): Promise<ContributionTimelineEntry[]> => {
+  const where: ActivityFilter = {
+    userId: userId,
+    type: 'contribution',
+  };
+
+  if (period === 'all') {
+  } else if (period === 'year' && year) {
+    const numericYear = parseInt(year);
+    const startDate = new Date(numericYear, 0, 1);
+    const endDate = new Date(numericYear, 11, 31, 23, 59, 59);
+    where.createdAt = {
+      gte: startDate,
+      lte: endDate,
+    };
+  } else if (period) {
+    const now = new Date();
+    const periodMap: Record<string, number> = {
+        'day': 24 * 60 * 60 * 1000,
+        'week': 7 * 24 * 60 * 60 * 1000,
+        'month': 30 * 24 * 60 * 60 * 1000,
+        'year': 365 * 24 * 60 * 60 * 1000
+    };
+    const duration = periodMap[period.toLowerCase()];
+
+    if (duration) {
+      where.createdAt = {
+        gte: new Date(now.getTime() - duration),
+      };
+    } else if (period.toLowerCase() !== 'all') {
+        where.createdAt = {
+            gte: new Date(now.getTime() - (365 * 24 * 60 * 60 * 1000)),
+          };
+    }
+  } else {
+    const now = new Date();
+    where.createdAt = {
+      gte: new Date(now.getTime() - (365 * 24 * 60 * 60 * 1000)),
+    };
+  }
+
+  const timelineResult = await prisma.gitHubActivity.groupBy({
+    by: ['createdAt'],
+    where,
+    _sum: { contributionCount: true },
+    orderBy: { createdAt: 'asc' },
+  });
+
+  return timelineResult.map((day) => ({
+    date: day.createdAt,
+    count: day._sum.contributionCount || 0,
+  }));
+}; 

--- a/src/types/github.ts
+++ b/src/types/github.ts
@@ -95,3 +95,9 @@ export interface GroupByRepository {
   repository: string;
   _count: number;
 }
+
+// Entry for a timeline, typically date and count
+export interface ContributionTimelineEntry {
+  date: Date;
+  count: number;
+}


### PR DESCRIPTION
## 변경사항
- GET /api/activities/chart 엔드포인트 추가
- 사용자별 Contribution 데이터를 기반으로 PNG 차트 생성 -> README.md 에 활용 가능하도록 제공
인증된 사용자와 공개 GitHub 사용자 모두 지원하는 로직 구현
(GitHub API rate limit 고려한 캐싱 또는 백오프 전략 보완 필요)

![Contribution Chart](https://git-test-backend.onrender.com/api/activities/chart.png?username=reizvoll&period=week&year=&width=500&height=250)

## 목적
- GitHub 활동 데이터를 시각화하여 README 또는 외부 페이지에서 사용할 수 있는 기능 추가
- 인증 여부와 관계없이 공개 사용자에 대한 유연한 지원 확보
- 향후 Contribution 기반 분석 및 시각화 기능 확장의 기반 마련