### PR TITLE
chore: set Prisma client output path for v7 compatibility

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,5 +1,6 @@
 generator client {
   provider = "prisma-client-js"
+  output   = "./node_modules/@prisma/client"
 }
 
 datasource db {


### PR DESCRIPTION
## 변경사항

- `schema.prisma` -> generator client 블록에 `output = "./node_modules/@prisma/client" `명시 (호환성 문제 방지)


## 목적

- 배포 환경에서 발생하는 경고 메시지 제거를 통해 장기적인 버전 호환성 및 안정성 확보