### PR TITLE
refactor: Change chart API endpoint, and update ouputs PNG to SVG

### DIFF
--- a/src/controllers/chartImageController.ts
+++ b/src/controllers/chartImageController.ts
@@ -73,7 +73,11 @@ export const generateContributionsChart = async (req: Request, res: Response) =>
       return res.status(404).send(); 
     }
 
-    const chartJSNodeCanvas = new ChartJSNodeCanvas({ width: outputWidth, height: outputHeight });
+    const chartJSNodeCanvas = new ChartJSNodeCanvas({ 
+      width: outputWidth, 
+      height: outputHeight,
+      type: 'svg'
+    });
 
     const labels = timelineData.map(entry => formatDateForChart(entry.date));
     const dataCounts = timelineData.map(entry => entry.count);
@@ -105,6 +109,11 @@ export const generateContributionsChart = async (req: Request, res: Response) =>
             text: `Contribution Analytics for ${username}`,
             font: { size: 18 }, // Adjusted font size
           },
+          tooltip: {
+            enabled: true,
+            mode: 'index' as const,
+            intersect: false,
+          },
         },
         scales: {
           x: {
@@ -121,13 +130,18 @@ export const generateContributionsChart = async (req: Request, res: Response) =>
             },
           },
         },
+        interaction: {
+          mode: 'nearest' as const,
+          axis: 'x' as const,
+          intersect: false
+        },
       },
     };
 
-    const buffer = await chartJSNodeCanvas.renderToBuffer(configuration);
+    const svg = await chartJSNodeCanvas.renderToDataURL(configuration);
 
-    res.setHeader('Content-Type', 'image/png');
-    res.send(buffer);
+    res.setHeader('Content-Type', 'image/svg+xml');
+    res.send(svg);
 
   } catch (error: unknown) {
     let message = 'Error generating chart image.';

--- a/src/routes/activityRoutes.ts
+++ b/src/routes/activityRoutes.ts
@@ -18,7 +18,7 @@ interface AuthRequest extends Request {
 
 const router = express.Router();
 
-router.get('/chart.png', generateContributionsChart);
+router.get('/chart', generateContributionsChart);
 router.use(authenticateToken);
 
 // Get user's GitHub activities


### PR DESCRIPTION
## 변경사항

- 엔드포인트 단순화 (`/api/activities/chart.png` -> `/api/activities/chart.svg`)
- 응답 포맷을 PNG에서 SVG로 변경하여 이미지 품질 향상

![Contribution Chart](https://git-test-backend.onrender.com/api/activities/chart?username=reizvoll&period=week&width=800&height=400)

## 목적

- 해상도에 구애받지 않고 다양한 환경에서 더 선명한 출력 개선을 위함